### PR TITLE
Add pagination for satellite selection

### DIFF
--- a/osint/osint.go
+++ b/osint/osint.go
@@ -1,34 +1,35 @@
 package osint
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
 	"os"
-	"github.com/TwiN/go-color"
-	"io/ioutil"
 	"strconv"
 	"strings"
-	"encoding/json"
-	"net/http"	
+
+	"github.com/TwiN/go-color"
 	"github.com/manifoldco/promptui"
-	"net/url"
 )
 
 const authURL = "https://www.space-track.org/ajaxauth/login"
 
 func extractNorad(str string) string {
-    start := strings.Index(str, "(")
-    end := strings.Index(str, ")")
-    if start == -1 || end == -1 || start >= end {
-        return ""
-    }
-    return str[start+1:end]
+	start := strings.Index(str, "(")
+	end := strings.Index(str, ")")
+	if start == -1 || end == -1 || start >= end {
+		return ""
+	}
+	return str[start+1 : end]
 }
 
 func PrintNORADInfo(norad string, name string) {
 	vals := url.Values{}
 	vals.Add("identity", os.Getenv("SPACE_TRACK_USERNAME"))
 	vals.Add("password", os.Getenv("SPACE_TRACK_PASSWORD"))
-	vals.Add("query", "https://www.space-track.org/basicspacedata/query/class/gp_history/format/tle/NORAD_CAT_ID/" + norad + "/orderby/EPOCH%20desc/limit/1")
+	vals.Add("query", "https://www.space-track.org/basicspacedata/query/class/gp_history/format/tle/NORAD_CAT_ID/"+norad+"/orderby/EPOCH%20desc/limit/1")
 
 	client := &http.Client{}
 
@@ -41,69 +42,84 @@ func PrintNORADInfo(norad string, name string) {
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		fmt.Println(color.Ize(color.Red, "  [!] ERROR: API REQUEST TO SPACE TRACK"))
 	}
-	respData, err := ioutil.ReadAll(resp.Body)
+	respData, err := io.ReadAll(resp.Body)
 
 	if err != nil {
 		fmt.Println(color.Ize(color.Red, "  [!] ERROR: API REQUEST TO SPACE TRACK"))
 	}
 
 	tleLines := strings.Fields(string(respData))
-	mid := (len(tleLines)/2) + 1
+	mid := (len(tleLines) / 2) + 1
 	lineOne := strings.Join(tleLines[:mid], " ")
 	lineTwo := strings.Join(tleLines[mid:], " ")
 	tle := ConstructTLE(name, lineOne, lineTwo)
 	PrintTLE(tle)
 }
 
-func SelectSatellite() string {
+func fetchData(page int, pageSize int) ([]Satellite, error) {
 	vals := url.Values{}
 	vals.Add("identity", os.Getenv("SPACE_TRACK_USERNAME"))
 	vals.Add("password", os.Getenv("SPACE_TRACK_PASSWORD"))
-	vals.Add("query", "https://www.space-track.org/basicspacedata/query/class/satcat/orderby/SATNAME asc/limit/10/emptyresult/show")
-
+	vals.Add("query",
+		fmt.Sprintf("https://www.space-track.org/basicspacedata/query/class/satcat/orderby/SATNAME asc/limit/%d,%d/emptyresult/show",
+			pageSize,
+			page*pageSize,
+		),
+	)
 	client := &http.Client{}
 
 	resp, err := client.PostForm(authURL, vals)
 	if err != nil {
-		fmt.Println(color.Ize(color.Red, "  [!] ERROR: API REQUEST TO SPACE TRACK"))
-		return ""
+		return nil, err
 	}
-
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		fmt.Println(color.Ize(color.Red, "  [!] ERROR: API REQUEST TO SPACE TRACK"))
-		return ""
-	}
-	respData, err := ioutil.ReadAll(resp.Body)
-
-	if err != nil {
-		fmt.Println(color.Ize(color.Red, "  [!] ERROR: API REQUEST TO SPACE TRACK"))
-		return ""
+		return nil, err
 	}
 
 	var sats []Satellite
-	if err := json.Unmarshal(respData, &sats); err != nil {
-		fmt.Println(color.Ize(color.Red, "  [!] ERROR: API REQUEST TO SPACE TRACK"))
-		return ""
+	if err := json.NewDecoder(resp.Body).Decode(&sats); err != nil {
+		return nil, err
 	}
 
-	var satStrings []string
-	for _, sat := range sats {
-		satStrings = append(satStrings, sat.SATNAME + " (" + sat.NORAD_CAT_ID + ")")
-	}
-	prompt := promptui.Select{
-		Label: "Select a Satellite 🛰",
-		Items: satStrings,
-	}
-	_, result, err := prompt.Run()
-	if err != nil {
-		fmt.Println(color.Ize(color.Red, "  [!] PROMPT FAILED"))
-		return ""
-	}
-	return result
+	return sats, nil
 }
 
-func GenRowString(intro string, input string) string{
+func SelectSatellite() string {
+	const pageSize = 10
+	page := 0
+	var satStrings []string
+
+	for {
+		items, err := fetchData(page, pageSize)
+		if err != nil {
+			fmt.Println(color.Ize(color.Red, "  [!] ERROR: API REQUEST TO SPACE TRACK"))
+			break
+		}
+		for _, sat := range items {
+			satStrings = append(satStrings, fmt.Sprintf("%s (%s)", sat.SATNAME, sat.NORAD_CAT_ID))
+		}
+		prompt := promptui.Select{
+			Label:        "Select a Satellite 🛰",
+			Items:        append(satStrings, fmt.Sprintf("Load next %d results", pageSize)),
+			Size:         5,
+			HideSelected: true,
+		}
+		cursorPos := len(satStrings) - pageSize
+		index, result, err := prompt.RunCursorAt(cursorPos, cursorPos-prompt.Size+1)
+		if err != nil {
+			fmt.Println(color.Ize(color.Red, "  [!] PROMPT FAILED"))
+			break
+		}
+		if index < len(satStrings) {
+			return result
+		}
+		page++
+	}
+	return ""
+}
+
+func GenRowString(intro string, input string) string {
 	var totalCount int = 4 + len(intro) + len(input) + 2
 	var useCount = 63 - totalCount
 	return "║ " + intro + ": " + input + strings.Repeat(" ", useCount) + " ║"
@@ -114,19 +130,19 @@ func Option(min int, max int) int {
 	var selection string
 	fmt.Scanln(&selection)
 	num, err := strconv.Atoi(selection)
-    if err != nil {
+	if err != nil {
 		fmt.Println(color.Ize(color.Red, "  [!] INVALID INPUT"))
 		return Option(min, max)
-    } else {
-		if (num == min) {
+	} else {
+		if num == min {
 			fmt.Println(color.Ize(color.Blue, " Escaping Orbit..."))
 			os.Exit(1)
 			return 0
-		} else if (num > min  && num < max + 1) {
+		} else if num > min && num < max+1 {
 			return num
 		} else {
 			fmt.Println(color.Ize(color.Red, "  [!] INVALID INPUT"))
 			return Option(min, max)
 		}
-    }
+	}
 }


### PR DESCRIPTION
This pull request introduces a pagination feature to address the limitation of the previous implementation, where only the first 10 elements from the API were displayed in the satellite selection list.

The query has been enhanced to utilize the offset feature as outlined in the API documentation:
> limit/x(,x?)
>
> Specifies the number of records to return. Takes an integer for an argument, with an optional second argument to specify offset. For example, /limit/10/ will return the first 10 records; /limit/10,5/ will show 10 records starting after record #5 (rows 6 through 15)

Further details in [API docs](https://www.space-track.org/documentation#api-restRulesAPIClasses)

**Next steps**
Please be aware that certain newly added satellites appearing in the results are causing parsing errors due to their structure.